### PR TITLE
Fix broken text overflows for queues in overview screen

### DIFF
--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -106,20 +106,53 @@
             <img src="{$dpath}img/content/market.png" class="overvieew4 tooltip" data-tooltip-content="{$LNG.lm_market}" style="opacity:0.8">
             </a>
         </div>
-        </div> 
-        <div class="gray_latdes overvieew3">
-            <div class="ricerche"><img src="{$dpath}img/iconav/ov_tech.png" class="overvieew27"><span class="overvieew9"><a href="game.php?page=research">
-                {if $buildInfo.tech}{$LNG.tech[$buildInfo.tech['id']]} <span class="level">({$buildInfo.tech['level']})</span><span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span>{else}{$LNG.ov_free}{/if}</a></span>
+        </div>
+		<div class="gray_latdes overvieew3">
+            <div class="ricerche">
+				<img src="{$dpath}img/iconav/ov_tech.png" class="overvieew27">
+				<span class="overvieew9">
+					<a href="game.php?page=research">
+						{if $buildInfo.tech}
+							<span class="timer" data-time="{$buildInfo.tech['timeleft']}">??:??:??</span>
+							- {$LNG.tech[$buildInfo.tech['id']]}
+							<span class="level">({$buildInfo.tech['level']})</span>
+						{else}
+							{$LNG.ov_free}
+						{/if}
+					</a>
+				</span>
             </div>
         </div>
         <div class="gray_latdes overvieew3">
-            <div class="costruzioni"><img src="{$dpath}img/iconav/ov_build.png" class="overvieew27"><span class="overvieew9"><a href="game.php?page=buildings">
-                {if $buildInfo.buildings}{$LNG.tech[$buildInfo.buildings['id']]} <span class="level">({$buildInfo.buildings['level']}) - </span><span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span>{else}{$LNG.ov_free}{/if}</a></span>
+            <div class="costruzioni">
+				<img src="{$dpath}img/iconav/ov_build.png" class="overvieew27">
+				<span class="overvieew9">
+					<a href="game.php?page=buildings">
+						{if $buildInfo.buildings}
+							<span class="timer" data-time="{$buildInfo.buildings['timeleft']}">??:??:??</span>
+							- {$LNG.tech[$buildInfo.buildings['id']]}
+							<span class="level">({$buildInfo.buildings['level']})</span>
+						{else}
+							{$LNG.ov_free}
+						{/if}
+					</a>
+				</span>
             </div>
         </div>
-        <div class="gray_latdes overvieew3">
-            <div class="flotte"><img src="{$dpath}img/iconav/ov_fleet.png" class="overvieew27"><span class="overvieew9"><a href="game.php?page=shipyard">
-                {if $buildInfo.fleet}{$LNG.tech[$buildInfo.fleet['id']]} <span class="level">({$buildInfo.fleet['level']})</span><br><span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span>{else}{$LNG.ov_free}{/if}</a></span>
+		<div class="gray_latdes overvieew3">
+            <div class="flotte">
+				<img src="{$dpath}img/iconav/ov_fleet.png" class="overvieew27">
+				<span class="overvieew9">
+					<a href="game.php?page=shipyard">
+						{if $buildInfo.fleet}
+							<span class="timer" data-time="{$buildInfo.fleet['timeleft']}">??:??:??</span>
+							- {$LNG.tech[$buildInfo.fleet['id']]}
+							<span class="level">({$buildInfo.fleet['level']})</span>
+						{else}
+							{$LNG.ov_free}
+						{/if}
+					</a>
+				</span>
             </div>
         </div>
 	</div>

--- a/styles/theme/gow/formate.css
+++ b/styles/theme/gow/formate.css
@@ -16142,7 +16142,7 @@ z-index: 99;}
     bottom: 4px;
     left: 0;
     right: 0;
-text-align: center;
+	text-align: center;
     font-size: 13px;
 	overflow: hidden;}
 .overvieew5:hover{color:#97a6bf}
@@ -16154,9 +16154,9 @@ text-align: center;
 
 .overvieew7{height: auto;
     position: relative;
-float: left;}
+	float: left;}
 .overvieew8{
-margin: 7px;
+	margin: 7px;
     border: 1px solid #091d2e;
     box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.5) !important;
     -webkit-box-shadow: 0 4px 3px 0 rgba(0, 0, 0, 0.5) !important;
@@ -16172,13 +16172,14 @@ margin: 7px;
 }
 
 .overvieew9{
+	display: inline-block;
     color: #8f8f8f;
-    line-height: 16px;
+    line-height: 20px;
     margin-left: 3px;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    width: 165px;
+    width: 80%;
     float: left;
     font-size: 11px;
     }


### PR DESCRIPTION
Fixes this in overlay panel:

![DarkslategrayHarpyeagle78](https://user-images.githubusercontent.com/9123992/106211774-8c97a000-61c9-11eb-879e-d652ebfd4cfe.png)
